### PR TITLE
Prevent buffer overflow when specifying an output file.

### DIFF
--- a/dcraw.c
+++ b/dcraw.c
@@ -10892,7 +10892,7 @@ thumbnail:
       write_ext = ".tiff";
     else
       write_ext = ".pgm\0.ppm\0.ppm\0.pam" + colors*5-5;
-    ofname = (char *) malloc (strlen(ifname) + 64);
+    ofname = (char *) malloc (strlen(outfile ? outfile : ifname) + 64);
     merror (ofname, "main()");
     if (write_to_stdout)
       strcpy (ofname,_("standard output"));


### PR DESCRIPTION
Hello,

Commit ad1ac306fc9563352f95c853f4aca91482d1bc88 introduced a nice feature to allow specifying an output file, but also a potential buffer overflow if you run dcraw.exe like:

`dcraw -O <80-chars-string> z.raw`

That does happens because the allocated memory is calculated from the input file. This PR does fix it.

Cheers.
